### PR TITLE
Add support for CMake 4

### DIFF
--- a/nrf-802154-sys/build.rs
+++ b/nrf-802154-sys/build.rs
@@ -5,6 +5,7 @@
 
 use std::env;
 use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::PathBuf;
 
 enum Series {
@@ -211,6 +212,10 @@ fn build(target: &Target) {
         .collect::<Vec<_>>()
         .join(" ");
 
+    if let Err(err) = patch_cmake_config(&manifest_path) {
+        println!("cargo:warning=Could not patch CMake configuration: {err}");
+    }
+
     cmake::Config::new("third_party/nordic/nrfxlib/nrf_802154")
         .define("CMAKE_BUILD_TYPE", "MinSizeRel")
         .define(
@@ -232,6 +237,56 @@ fn build(target: &Target) {
         .define("BUILD_TESTING", "OFF")
         .build_target("nrf-802154-driver")
         .build();
+}
+
+/// Adds `cmake_minimum_required` to the upstream `CMakeLists.txt`.
+///
+/// This is a required property starting from CMake 4.0. See
+/// [CMP0000](https://cmake.org/cmake/help/latest/policy/CMP0000.html) for more details.
+fn patch_cmake_config(manifest_path: &PathBuf) -> Result<(), String> {
+    let cmake_major_version = get_cmake_major_version().unwrap_or(0);
+    if cmake_major_version < 4 {
+        return Ok(());
+    }
+
+    let cmake_lists_path =
+        manifest_path.join("third_party/nordic/nrfxlib/nrf_802154/CMakeLists.txt");
+    let content = std::fs::read_to_string(&cmake_lists_path)
+        .map_err(|err| format!("failed to read {}: {err}", cmake_lists_path.display()))?;
+    if content.contains("cmake_minimum_required") {
+        return Ok(());
+    }
+
+    let patched = format!("cmake_minimum_required(VERSION 3.5)\n{content}");
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .create(true)
+        .open(&cmake_lists_path)
+        .map_err(|err| {
+            format!(
+                "failed to open {} for patching: {err}",
+                cmake_lists_path.display()
+            )
+        })?;
+    file.write_all(patched.as_bytes())
+        .map_err(|err| format!("failed to write {}: {err}", cmake_lists_path.display()))?;
+
+    Ok(())
+}
+
+fn get_cmake_major_version() -> Option<u32> {
+    let output = std::process::Command::new("cmake")
+        .arg("--version")
+        .output()
+        .ok()?;
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix("cmake version "))
+        .and_then(|version| version.split('.').next())
+        .and_then(|major| major.parse().ok())
 }
 
 fn main() {


### PR DESCRIPTION
Appends `cmake_minimum_required(VERSION 3.5)` to [`CMakeLists.txt`](https://github.com/nrfconnect/sdk-nrfxlib/blob/3b210a24d3bc7ecfc268e0feab6436306b11e7cb/nrf_802154/CMakeLists.txt) if building with CMake 4 or newer. This is a required property starting from CMake 4.0; see [CMP0000](https://cmake.org/cmake/help/latest/policy/CMP0000.html) for more details. CMake 4 dropped support for versions older than 3.5, so that was the minimum version chosen here.

Please let me know if there is a better way to do this. Maybe we could get this change upstreamed instead?

<details>
<summary>Build crash log</summary>

```
$ cmake --version                                                                   
cmake version 4.1.2

CMake suite maintained and supported by Kitware (kitware.com/cmake).

$ cargo build --package nrf-802154-sys --features nrf52 --target thumbv7em-none-eabi
   Compiling nrf-802154-sys v0.1.0 (/home/sandro/dev/nrf-802154/nrf-802154-sys)
error: failed to run custom build command for `nrf-802154-sys v0.1.0 (/home/sandro/dev/nrf-802154/nrf-802154-sys)`

Caused by:
  process didn't exit successfully: `/home/sandro/dev/nrf-802154/target/debug/build/nrf-802154-sys-50be96cd42e22d6c/build-script-build` (exit status: 101)
  --- stdout
  CMAKE_TOOLCHAIN_FILE_thumbv7em-none-eabi = None
  CMAKE_TOOLCHAIN_FILE_thumbv7em_none_eabi = None
  TARGET_CMAKE_TOOLCHAIN_FILE = None
  CMAKE_TOOLCHAIN_FILE = None
  CMAKE_GENERATOR_thumbv7em-none-eabi = None
  CMAKE_GENERATOR_thumbv7em_none_eabi = None
  TARGET_CMAKE_GENERATOR = None
  CMAKE_GENERATOR = None
  CMAKE_PREFIX_PATH_thumbv7em-none-eabi = None
  CMAKE_PREFIX_PATH_thumbv7em_none_eabi = None
  TARGET_CMAKE_PREFIX_PATH = None
  CMAKE_PREFIX_PATH = None
  CMAKE_thumbv7em-none-eabi = None
  CMAKE_thumbv7em_none_eabi = None
  TARGET_CMAKE = None
  CMAKE = None
  -- The C compiler identification is Clang 21.1.8
  -- The CXX compiler identification is Clang 21.1.8
  -- Detecting C compiler ABI info
  -- Detecting C compiler ABI info - done
  -- Check for working C compiler: /nix/store/482i7k840pk0cmv6qhf4rf5gyah1lq8l-clang-21.1.8/bin/clang - skipped
  -- Detecting C compile features
  -- Detecting C compile features - done
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /nix/store/482i7k840pk0cmv6qhf4rf5gyah1lq8l-clang-21.1.8/bin/clang - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Configuring incomplete, errors occurred!

  --- stderr
  running: cd "/home/sandro/dev/nrf-802154/target/thumbv7em-none-eabi/debug/build/nrf-802154-sys-18598bf977229e16/out/build" && CMAKE_PREFIX_PATH="" LC_ALL="C" "cmake" "/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfxlib/nrf_802154" "-B" "/home/sandro/dev/nrf-802154/target/thumbv7em-none-eabi/debug/build/nrf-802154-sys-18598bf977229e16/out/build" "-DCMAKE_BUILD_TYPE=MinSizeRel" "-DCMAKE_C_FLAGS=-Werror=implicit-function-declaration -fshort-enums -DCONFIG_MPSL -DNRF_802154_INTERNAL_SWI_IRQ_HANDLING=0 -DNRF_802154_REQUEST_IMPL=0 -DNRF_802154_NOTIFICATION_IMPL=0 -DNRF_802154_EGU_INSTANCE=NRF_EGU0 -DNRF52840_XXAA -mcpu=cortex-m4 -mfloat-abi=soft -mthumb -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/arm/CMSIS_5/CMSIS/Core/Include -I/home/sandro/dev/nrf-802154/nrf-802154-sys/include -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfx -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfx/mdk -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfxlib/mpsl/include -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfxlib/mpsl/fem/include -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfxlib/nrf_802154/sl/sl/include -I/home/sandro/dev/nrf-802154/nrf-802154-sys/third_party/nordic/nrfx/templates" "-DCMAKE_C_FLAGS_RELEASE=-O3 -DNDEBUG" "-DCMAKE_SYSTEM_NAME=Generic" "-DCMAKE_SYSTEM_PROCESSOR=ARM" "-DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY" "-DCMAKE_C_COMPILER=clang" "-DCMAKE_C_COMPILER_TARGET=thumbv7em-none-eabi" "-DCMAKE_CXX_COMPILER=clang" "-DCMAKE_CXX_COMPILER_TARGET=thumbv7em-none-eabi" "-DBUILD_SHARED_LIBS=OFF" "-DBUILD_TESTING=OFF" "-DCMAKE_INSTALL_PREFIX=/home/sandro/dev/nrf-802154/target/thumbv7em-none-eabi/debug/build/nrf-802154-sys-18598bf977229e16/out" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -mthumb -march=armv7e-m -w" "-DCMAKE_ASM_FLAGS= -ffunction-sections -fdata-sections -mthumb -march=armv7e-m -w" "-DCMAKE_ASM_COMPILER=/nix/store/kbw2j1vag664b3sj3rjwz9v53cqx87sb-gcc-wrapper-15.2.0/bin/gcc"
  CMake Warning (dev) in CMakeLists.txt:
    No project() command is present.  The top-level CMakeLists.txt file must
    contain a literal, direct call to the project() command.  Add a line of
    code such as

      project(ProjectName)

    near the top of the file, but after cmake_minimum_required().

    CMake is pretending there is a "project(Project)" command on the first
    line.
  This warning is for project developers.  Use -Wno-dev to suppress it.

  CMake Warning (dev) in CMakeLists.txt:
    cmake_minimum_required() should be called prior to this top-level project()
    call.  Please see the cmake-commands(7) manual for usage documentation of
    both commands.
  This warning is for project developers.  Use -Wno-dev to suppress it.

  CMake Warning (dev) at driver/CMakeLists.txt:119 (target_link_libraries):
    Policy CMP0079 is not set: target_link_libraries allows use with targets in
    other directories.  Run "cmake --help-policy CMP0079" for policy details.
    Use the cmake_policy command to set the policy and suppress this warning.

    Target

      nrf-802154-driver-interface

    is not created in this directory.  For compatibility with older versions of
    CMake, link library

      nrf-802154-common-interface

    will be looked up in the directory in which the target was created rather
    than in this calling directory.
  This warning is for project developers.  Use -Wno-dev to suppress it.

  CMake Warning (dev) at serialization/CMakeLists.txt:91 (target_link_libraries):
    Policy CMP0079 is not set: target_link_libraries allows use with targets in
    other directories.  Run "cmake --help-policy CMP0079" for policy details.
    Use the cmake_policy command to set the policy and suppress this warning.

    Target

      nrf-802154-serialization-interface

    is not created in this directory.  For compatibility with older versions of
    CMake, link library

      nrf-802154-common-interface

    will be looked up in the directory in which the target was created rather
    than in this calling directory.
  This warning is for project developers.  Use -Wno-dev to suppress it.

  CMake Error in CMakeLists.txt:
    No cmake_minimum_required command is present.  A line of code such as

      cmake_minimum_required(VERSION 4.1)

    should be added at the top of the file.  The version specified may be lower
    if you wish to support older CMake versions for this project.  For more
    information run "cmake --help-policy CMP0000".



  thread 'main' (274914) panicked at /home/sandro/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cmake-0.1.57/src/lib.rs:1132:5:

  command did not execute successfully, got: exit status: 1

  build script failed, must exit now
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
</details>

<details>
<summary>CMake 3.4 as minimum version</summary>

```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
</details>